### PR TITLE
Fix build fail for server and agent

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "dependencies": {
     "body-parser": "latest",
-    "exec": "",
     "express": "^4.15.3",
     "fs": "",
     "line-reader": "",
@@ -11,7 +10,6 @@
     "os": "",
     "request": "",
     "request-debug": "",
-    "socket": "",
     "sys": ""
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -6,8 +6,6 @@
     "line-reader": "",
     "node-gyp": "",
     "fs": "",
-    "socket": "",
-    "exec": "",
     "request-debug": "",
     "body-parser": "latest",
     "sys": "",


### PR DESCRIPTION
I noticed that this problem was referred in issue #15 and was told that ignoring this fail is safe. The error references an old version of microtime that needed node-waf to build (which has been succeeded by node-gyp). I did the following to track down which package was breaking the build due to dependency failure to find that socket was the culprit. After removing socket from both server and agent package.json files, npm install builds without failure.

* Show node depency tree:
```
npm ls
```

* Got the following truncated output:
```
+-- request-debug@0.2.0
| `-- stringify-clone@1.1.1
+-- UNMET DEPENDENCY socket@
`-- sys@0.0.1
```

I also removed exec since its succeeded by `child_process.execFile` anyway.

Now you can close issue #15 for reals :p  