### PR TITLE
Add docker-compose files

### DIFF
--- a/docker-compose.config.json
+++ b/docker-compose.config.json
@@ -1,0 +1,30 @@
+{
+  "token": "1234567890ABCDEFGHJKLMNOP",
+  "docker": "../docker",
+  "server_port": "3000",
+  "agent_port": "3001",
+  "layout": [
+    {
+      "node": "agent",
+      "nginx": "-p 80:80"
+    }
+  ],
+  "hb": [
+    {
+      "node": "agent",
+      "nginx": "80"
+    }
+  ],
+  "container_host_constraints": [
+    {
+      "container": "nginx,agent"
+    }
+  ],
+  "automatic_heartbeat": "enabled",
+  "heartbeat_interval": "300000",
+  "syslog": "dmesg",
+  "web_username": "admin",
+  "web_password": "admin",
+  "web_connect": "server",
+  "web_port": "3003"
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '2'
+services:
+  server:
+    image: "node:alpine"
+    volumes:
+      - .:/picluster
+      - ./docker-compose.config.json:/picluster/config.json
+    ports:
+      - "3000:3000"
+    working_dir: /picluster/server
+    command: ["sh", "-c", "npm install --production;node server.js;"]
+    links:
+      - agent
+  agent:
+    image: "node:alpine"
+    volumes:
+      - .:/picluster
+      - ./docker-compose.config.json:/picluster/config.json
+      - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - "3001:3001"
+    working_dir: /picluster/agent
+    command: ["sh", "-c", "apk update;apk upgrade;apk add docker;npm install --production;node agent.js"]
+  webconsole:
+    image: "node:alpine"
+    volumes:
+      - .:/picluster
+      - ./docker-compose.config.json:/picluster/config.json
+    ports:
+      - "3003:3003"
+    working_dir: /picluster/web
+    command: ["sh", "-c", "npm install --production;node webconsole.js;"]
+    links:
+      - server


### PR DESCRIPTION
This is possibly not the best docker compose file in the world but it does make developing and testing an awful lot quicker than using a VM.

To try this out run `docker-compose up` from the picluster directory.

~~Note: This probably won't work on Windows or Mac since it mounts the docker socket into the agent container to be able to run docker commands on the host machine (maybe docker will do the same using the vm it runs in on Windows and macOS?).~~

I just tested this on my Macbook and it's working fine! It just dawned on me, we could use this to distribute PiCluster as a Docker image!